### PR TITLE
GROUP-105 Migrate to AWS

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -6,6 +6,7 @@ env:
   IMAGE_NAME: grouphq/group-service
   VERSION: ${{ github.sha }}
   NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+  AWS_RDS_ROOT_CERT_US_EAST_1: https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
 
 jobs:
   build:
@@ -79,6 +80,10 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+      - name: Download AWS RDS Root Certificate for us-east-1
+        run: |
+          mkdir -p ./.postgresql
+          curl -o ./.postgresql/root.crt ${{ env.AWS_RDS_ROOT_CERT_US_EAST_1 }}
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ repositories {
 
 bootBuildImage {
     imageName = "${project.name}"
+    bindings = [
+            "${projectDir}/.postgresql:/home/cnb/.postgresql:ro".toString()
+    ]
     environment = ["BP_JVM_VERSION" : "17.*"]
 }
 

--- a/src/main/java/org/grouphq/groupservice/config/OpenAiApiConfig.java
+++ b/src/main/java/org/grouphq/groupservice/config/OpenAiApiConfig.java
@@ -42,6 +42,6 @@ public class OpenAiApiConfig {
         private int maxAttempts;
         private int initialDelay;
         private int maxDelay;
-        private int jitterFactor;
+        private double jitterFactor;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,8 @@ server:
 spring:
   r2dbc:
     url: r2dbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
+    properties:
+      sslMode: VERIFY_FULL
   flyway:
     url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups?ssl=true&sslMode=verify-full
   rabbitmq:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,37 @@
+server:
+  error:
+    include-stacktrace: never
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
+  flyway:
+    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
+  rabbitmq:
+    host: ${RABBITMQ_HOST:grouphq-rabbitmq}
+openai:
+  enabled: true
+  api_key: ${OPEN_AI_API_KEY}
+  max-tokens: 500
+  model-id: gpt-3.5-turbo
+  retry-config:
+    initial-delay: 1000
+    max-attempts: 3
+    max-delay: 5000
+    jitter-factor: 1.5
+group:
+  loader:
+    enabled: true
+    group-service-jobs:
+      load-groups:
+        initial-delay: 0
+        fixed-delay: 250
+        initial-group-count: 1
+        fixed-group-addition-count: 1
+      expire-groups:
+        initial-delay: 0
+        fixed-delay: 179
+        group-lifetime: 1800
+      load-members:
+        initial-delay: 5
+        fixed-delay: 120
+        member-join-max-delay: 120

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,7 +17,7 @@ openai:
     initial-delay: 1000
     max-attempts: 3
     max-delay: 5000
-    jitter-factor: 1.5
+    jitter-factor: 0.5
 group:
   loader:
     enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ spring:
   r2dbc:
     url: r2dbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
   flyway:
-    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
+    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups?ssl=true&sslMode=verify-full
   rabbitmq:
     host: ${RABBITMQ_HOST:grouphq-rabbitmq}
 openai:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ openai:
     initial-delay: 1000
     max-attempts: 3
     max-delay: 5000
-    jitter-factor: 1.5
+    jitter-factor: 0.5
 spring:
   application:
     name: group-service


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
- Adds `application-prod.yml` file. Previously this would have been added by Kustomize via Kubernetes, but since we're migrating away from Kubernetes, it's easier to just keep it with the application. Can be toggled by setting the `SPRING_PROFILES_ACTIVE` environment variable to `prod`
- Updates `build.gradle`'s `bootBuildImage` task to bind a volume to the packaged container. This volume is the root certificate authority needed to verify the postgres server's certificate when connecting to the AWS RDS Postgres instance with SSL.
- Steps were added to the commit stage to download and store the latest root certificate authority from Amazon to be used when connecting to the Postgres instance

### Additional Info / Concerns
[Types of SSL Modes supported by Postgres](https://www.postgresql.org/docs/current/libpq-ssl.html)
![image](https://github.com/GroupHQ/group-service/assets/88041024/684e8823-c6bf-4ec2-9480-f03dae29d880)

Difference between verify-ca and verify-full:
> The difference between verify-ca and verify-full depends on the policy of the root CA. If a public CA is used, verify-ca allows connections to a server that somebody else may have registered with the CA. In this case, verify-full should always be used. If a local CA is used, or even a self-signed certificate, using verify-ca often provides enough protection.

Why prefer is the default, but not recommended for secure deployments:
> The default value for sslmode is prefer. As is shown in the table, this makes no sense from a security point of view, and it only promises performance overhead if possible. It is only provided as the default for backward compatibility, and is not recommended in secure deployments.

Finally, picking verify-full gives us more confidence that we're speaking to the server we're intending to on an encrypted connection, helping to prevent man-in-the-middle attacks (an attacker would not only need to intercept application traffic on our AWS private VPC, but also intercept the certificate download from the GitHub Action initiating the download).