### PR TITLE
GROUP-105 Add AWS RDS certificate file to container

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -95,6 +95,8 @@ jobs:
           chmod +x gradlew
           ./gradlew bootBuildImage \
           --imageName ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+      - name: Add Amazon RDS Root Certificate (us-east-1)
+        run: docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }} .
       - name: OCI image vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/grouphq/group-service
+
+ARG cert=https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
+
+ADD $cert /home/cnb/.postgresql/root.crt

--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,6 @@ repositories {
 
 bootBuildImage {
     imageName = "${project.name}"
-    bindings = [
-            "${projectDir}/.postgresql:/home/cnb/.postgresql:ro".toString()
-    ]
     environment = ["BP_JVM_VERSION" : "17.*"]
 }
 


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
The previous PR (#37) for GROUP-105 incorrectly specified a binding to the `bootBuildImage` task. The goal was to add the certificate through this binding, but files added through this binding are only present while the image is being built.

To persist the certificate in the image, a separate `Dockerfile` in the project directory was added. This file takes the image created by the `bootBuildImage` task and adds another layer to it. The layer simply pulls the certificate from the URL and adds it to the path expected by Spring Data (at /home/cnb/.postgres).
