### PR TITLE
GROUP-105 Add permission to read certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,8 @@ FROM ghcr.io/grouphq/group-service
 ARG cert=https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
 
 ADD $cert /home/cnb/.postgresql/root.crt
+
+USER root
+RUN chown cnb:cnb /home/cnb/.postgresql/root.crt
+
+USER cnb


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
The following lines were added to the Dockerfile responsible for adding the certificate:
```dockerfile
USER root
RUN chown cnb:cnb /home/cnb/.postgresql/root.crt

USER cnb
```

This was a necessary change since only the root user was allowed to read the certificate. This change should allow the application to read the certificate and communicate with the AWS RDS server over SSL.
