### PR TITLE
GROUP-105 Updated configuration to correctly identify root certs paths

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,13 +12,9 @@ spring:
     url: r2dbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
     properties:
       sslMode: VERIFY_FULL
-      sslRootCert: "classpath:aws/postgres/root.crt"
+      sslRootCert: "aws/postgres/root.crt"
   flyway:
-    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups
-    jdbc-properties:
-      ssl: true
-      sslMode: verify_full
-      sslRootCert: "classpath:aws/postgres/root.crt"
+    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups?ssl=true&sslMode=verify-full&sslRootCert=classpath:aws/postgres/root.crt
   rabbitmq:
     host: ${RABBITMQ_HOST:grouphq-rabbitmq}
     port: 5671

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,7 @@ spring:
   r2dbc:
     username: user
     password: password
-    url: r2dbc:postgresql://localhost:5432/grouphq_group
+    url: r2dbc:postgresql://localhost:5432/grouphq_groups
     pool:
       max-create-connection-time: 2s
       initial-size: 5
@@ -54,7 +54,7 @@ spring:
   flyway:
     user: ${spring.r2dbc.username}
     password: ${spring.r2dbc.password}
-    url: jdbc:postgresql://localhost:5432/grouphq_group
+    url: jdbc:postgresql://localhost:5432/grouphq_groups
 #  config:
 #    import: optional:configserver:${SPRING_CLOUD_CONFIG_URI:http://localhost:8888}
   cloud:


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
This pull request solves two issues with how the root certificate for the Postgres server is passed to the R2DBC and JDBC drivers.

#### R2DBC Driver Handling of sslRootCert Property
The driver searches in the classpath by default. Providing a the `classpath:` prefix should then be avoided. If the file cannot be found in the classpath, it's searched as a normal file URL.

[Source](https://github.com/pgjdbc/r2dbc-postgresql/commit/97fc297f0cf05e63192b45285735c0ffc3b45966#diff-6743f41b93ec1eabcaa9465dfe3716fa54f48714cac4c43906ab0b704a86f3e9)

#### JDBC Driver Handling of sslRootCert Property via Flyway
The driver seems to use the `classpath:` prefix. However, we have to provide the certificate path via the URL, since Flyway Community Edition does not support JDBC properties passed through the YML configuration.
