### PR TITLE
GROUP-105 Updated Flyway URL to Correctly Identify sslRootCert

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
       sslMode: VERIFY_FULL
       sslRootCert: "aws/postgres/root.crt"
   flyway:
-    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups?ssl=true&sslMode=verify-full&sslRootCert=classpath:aws/postgres/root.crt
+    url: jdbc:postgresql://${POSTGRES_HOST:grouphq-postgres}/grouphq_groups?ssl=true;sslMode=verify-full;sslRootCert=classpath:aws/postgres/root.crt
   rabbitmq:
     host: ${RABBITMQ_HOST:grouphq-rabbitmq}
     port: 5671


### PR DESCRIPTION
<!--- Make sure to add GROUP-# (with # your related issue number) at the beginning of your pull request title, followed by a space! -->
### Description of Changes
It turns out that Flyway doesn't recognize the use of ampersands (&) to delimit properties in a JDBC URL. Instead, it recognizes only semicolons (;) as the delimiter. Many examples online use ampersands to delimit properties in a JDBC string, but there are docs that specify the use of semicolons. 

Sources on using semicolons:
[MS SQL Server](https://www.baeldung.com/java-jdbc-url-format#jdbc-url-format-for-microsoft-sql-server)
[Java Docs](https://docs.oracle.com/javase/tutorial/jdbc/basics/connecting.html)
[PostgreSQL](https://jdbc.postgresql.org/documentation/use/#connection-parameters)

The PostgreSQL docs show an example using ampersands, so it's kind of weird why only semicolons work in the Flyway URL. Maybe a JDBC driver restriction?
